### PR TITLE
Update utils.py to fix sqlite3.OperationalError

### DIFF
--- a/swarm_to_sqlite/utils.py
+++ b/swarm_to_sqlite/utils.py
@@ -91,7 +91,7 @@ def save_checkin(checkin, db):
         cleanup_user(user)
         db["users"].insert(user, pk="id", replace=True)
         photo["user"] = user["id"]
-        photos_table.insert(photo, replace=True)
+        photos_table.insert(photo, replace=True, alter=True)
     # Handle posts
     posts_table = db.table("posts", pk="id")
     for post in posts:
@@ -102,7 +102,7 @@ def save_checkin(checkin, db):
             db["post_sources"].insert(post.pop("source"), pk="id", replace=True).last_pk
         )
         post["checkin"] = checkin["id"]
-        posts_table.insert(post, foreign_keys=("post_source", "checkin"), replace=True)
+        posts_table.insert(post, foreign_keys=("post_source", "checkin"), replace=True, alter=True)
 
 
 def cleanup_user(user):


### PR DESCRIPTION
Fixes the errors:
- sqlite3.OperationalError: table posts has no column named text
- sqlite3.OperationalError: table photos has no column named hasSticker

That will cause sqlite-utils to notice if there's a missing column and add it. As recommended by @simonw